### PR TITLE
Created local storage

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,3 +55,10 @@ const myTempStorage = {
   email: '',
   message: '',
 };
+
+form.addEventListener('change', () => {
+  myTempStorage.name = document.getElementById('name').value;
+  myTempStorage.email = document.getElementById('email').value;
+  myTempStorage.message = document.getElementById('message').value;
+  localStorage.setItem('storageString', JSON.stringify(myTempStorage));
+});

--- a/index.js
+++ b/index.js
@@ -62,3 +62,9 @@ form.addEventListener('change', () => {
   myTempStorage.message = document.getElementById('message').value;
   localStorage.setItem('storageString', JSON.stringify(myTempStorage));
 });
+
+const storageObject = JSON.parse(localStorage.getItem('storageString'));
+
+document.getElementById('name').value = storageObject.name;
+document.getElementById('email').value = storageObject.email;
+document.getElementById('message').value = storageObject.message;

--- a/index.js
+++ b/index.js
@@ -48,3 +48,10 @@ form.addEventListener('submit', (e) => {
     errorMessage.classList.remove('display-none');
   }
 });
+
+// Local Storage
+const myTempStorage = {
+  name: '',
+  email: '',
+  message: '',
+};


### PR DESCRIPTION
# Project requires local storage for name, email, and messages. :heavy_check_mark:  :heavy_check_mark: 
In order to preserve the data that the user fills out in the form, we need to save it to the local storage of the browser. By doing so, when the page is reloaded, the data will be retrieved from the local storage and displayed in the form, allowing the user to continue where they left off without having to re-enter the information ⚡👌.

### Done :memo: 
- [x] Ensure a seamless user experience.
- [x] Whenever the user modifies the content of any input field, we should save the data to the local storage.
- [x] Upon loading the page, we should pre-fill the input fields with any data that exists in the local storage.
- [x] Updated README.

### Highlights :star: :star2: 
- Linters are passing.
- Used GitHub flow
- JS Best practices.

### :tada: :100: 
![PeacefulNecessaryGrasshopper-max-1mb](https://user-images.githubusercontent.com/57197702/235986967-7aa5fee4-ca41-481d-9d64-f04eebba3280.gif)
